### PR TITLE
Fix double-slash URLs: remove trailing slash from site url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ logo:               'assets/img/logo.png'
 background:         'assets/img/background.jpg'  # Static background for non-homepage pages
 tiled_bg:           false   # Set this true if you want to tile your background image, otherwise it will be covered
 locale:             en_US
-url:                https://www.xuminghuang.com/
+url:                https://www.xuminghuang.com
 # Jekyll
 permalink:          /:title/
 markdown:           kramdown


### PR DESCRIPTION
The trailing slash in url config combined with permalink patterns produced URLs like xuminghuang.com//deep-work/ which Google refused to index. All 17 pages showed 'Discovered - currently not indexed' in Search Console due to these malformed URLs.